### PR TITLE
Show post-specific images in related posts section

### DIFF
--- a/docs/_includes/archive-single.html
+++ b/docs/_includes/archive-single.html
@@ -1,0 +1,32 @@
+{% if post.header.teaser %}
+  {% capture teaser %}{{ post.header.teaser }}{% endcapture %}
+{% elsif post.header.image %}
+  {% capture teaser %}{{ post.header.image }}{% endcapture %}
+{% else %}
+  {% assign teaser = site.teaser %}
+{% endif %}
+
+{% if post.id %}
+  {% assign title = post.title | markdownify | remove: "<p>" | remove: "</p>" %}
+{% else %}
+  {% assign title = post.title %}
+{% endif %}
+
+<div class="{{ include.type | default: 'list' }}__item">
+  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">
+    {% if include.type == "grid" and teaser %}
+      <div class="archive__item-teaser">
+        <img src="{{ teaser | relative_url }}" alt="">
+      </div>
+    {% endif %}
+    <h2 class="archive__item-title no_toc" itemprop="headline">
+      {% if post.link %}
+        <a href="{{ post.link }}">{{ title }}</a> <a href="{{ post.url | relative_url }}" rel="permalink"><i class="fas fa-link" aria-hidden="true" title="permalink"></i><span class="sr-only">Permalink</span></a>
+      {% else %}
+        <a href="{{ post.url | relative_url }}" rel="permalink">{{ title }}</a>
+      {% endif %}
+    </h2>
+    {% include page__meta.html type=include.type %}
+    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+  </article>
+</div>

--- a/docs/_posts/2022-02-24-About -This-Site.md
+++ b/docs/_posts/2022-02-24-About -This-Site.md
@@ -1,5 +1,7 @@
 ---
 title:  "What's this all about?"
+header:
+  teaser: /assets/images/about_teaser.svg
 categories:
   - Admin
 tags:

--- a/docs/_posts/2022-03-03-Nuclear-Posture.md
+++ b/docs/_posts/2022-03-03-Nuclear-Posture.md
@@ -1,6 +1,8 @@
 ---
 title:  "Nuclear Posture: A nuclear noobs intro"
 classes: wide
+header:
+  teaser: /assets/images/d5_banner.png
 categories:
   - Nuclear
 tags:

--- a/docs/_posts/2022-04-01-Blockchain-basics copy.md
+++ b/docs/_posts/2022-04-01-Blockchain-basics copy.md
@@ -1,6 +1,8 @@
 ---
 title:  "Blockchain Basics"
 classes: wide
+header:
+  teaser: /assets/images/githistory.png
 categories:
   - software
 tags:

--- a/docs/_posts/2023-01-18-Lets-talk-crypto.md
+++ b/docs/_posts/2023-01-18-Lets-talk-crypto.md
@@ -1,6 +1,8 @@
 ---
 title:  "Let's talk Crypto[graphy]"
 classes: wide
+header:
+  teaser: /assets/images/RSA_key_banner.png
 categories:
   - software
 tags:

--- a/docs/_posts/2023-01-25-TidByt-Hacking.md
+++ b/docs/_posts/2023-01-25-TidByt-Hacking.md
@@ -1,6 +1,8 @@
 ---
 title:  "Adventures with TidByt"
 classes: wide
+header:
+  teaser: /assets/images/tidbyt_banner.jpg
 categories:
   - software
 tags:

--- a/docs/_posts/2023-5-18-Always-Never.md
+++ b/docs/_posts/2023-5-18-Always-Never.md
@@ -1,6 +1,8 @@
 ---
 title:  "Always/Never Paradox and Platform Trust & Safety"
 classes: wide
+header:
+  teaser: /assets/images/titan2.png
 categories:
   - software
   - nuclear

--- a/docs/_posts/2025-06-22-Modes-Of-Nuclear-Proliferation.md
+++ b/docs/_posts/2025-06-22-Modes-Of-Nuclear-Proliferation.md
@@ -1,6 +1,8 @@
 ---
 title:  "Modes of Nuclear Proliferation"
 classes: wide
+header:
+  teaser: /assets/images/fordow.png
 categories:
   - nuclear
 tags:

--- a/docs/_posts/2026-05-19-Building-Ledger.md
+++ b/docs/_posts/2026-05-19-Building-Ledger.md
@@ -3,6 +3,7 @@ title: "Building Ledger: A Personal Finance App Built With Claude"
 classes: wide
 header:
   image: /assets/images/claude_header_option3.svg
+  teaser: /assets/images/claude_header_option3.svg
 categories:
   - software
 tags:

--- a/docs/_posts/2026-05-19-Building-Ledger.md
+++ b/docs/_posts/2026-05-19-Building-Ledger.md
@@ -2,7 +2,8 @@
 title: "Building Ledger: A Personal Finance App Built With Claude"
 classes: wide
 header:
-  image: /assets/images/claude_header_option3.svg
+  overlay_image: /assets/images/claude_header_option3.svg
+  overlay_filter: 0
   teaser: /assets/images/claude_header_option3.svg
 categories:
   - software

--- a/docs/assets/images/about_teaser.svg
+++ b/docs/assets/images/about_teaser.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450">
+  <rect width="800" height="450" fill="#1a1a2e"/>
+  <rect x="80" y="90" width="640" height="8" rx="4" fill="#4a9eff" opacity="0.8"/>
+  <rect x="80" y="118" width="480" height="6" rx="3" fill="#ffffff" opacity="0.4"/>
+  <rect x="80" y="140" width="560" height="6" rx="3" fill="#ffffff" opacity="0.3"/>
+  <rect x="80" y="162" width="520" height="6" rx="3" fill="#ffffff" opacity="0.3"/>
+  <rect x="80" y="200" width="400" height="6" rx="3" fill="#ffffff" opacity="0.25"/>
+  <rect x="80" y="222" width="580" height="6" rx="3" fill="#ffffff" opacity="0.25"/>
+  <rect x="80" y="244" width="440" height="6" rx="3" fill="#ffffff" opacity="0.25"/>
+  <rect x="80" y="282" width="500" height="6" rx="3" fill="#ffffff" opacity="0.2"/>
+  <rect x="80" y="304" width="360" height="6" rx="3" fill="#ffffff" opacity="0.2"/>
+  <rect x="80" y="326" width="540" height="6" rx="3" fill="#ffffff" opacity="0.2"/>
+  <text x="400" y="390" font-family="Georgia, serif" font-size="22" fill="#4a9eff" opacity="0.9" text-anchor="middle">mostly ramblings</text>
+</svg>


### PR DESCRIPTION
Override archive-single.html to fall back to post.header.image when
post.header.teaser is absent, so the "You may also enjoy" grid shows
each post's own banner rather than the global default profile image.

Add header.teaser to every post pointing to its existing banner image,
and create a simple SVG teaser for the "About" post which had none.

https://claude.ai/code/session_011PxD7458qaTbHgqeS3UxkK