### PR TITLE
Rewrite work page with full career history and narrative prose

### DIFF
--- a/docs/_pages/work.md
+++ b/docs/_pages/work.md
@@ -2,14 +2,35 @@
 title: "Work"
 permalink: /work/
 ---
-I'm an software engineering manager at Meta on the scaled business team. I've worked across Facebook and Instagram business surfaces since 2018 and have led work on Meta's advertiser guidance systems, new advertiser onboarding, ads performance, and scaled communications. Aside from business surfaces I've had the opportunity to be involved in Meta's COVID-19 and Ukraine War crisis response teams. Prior to my time at Meta I was a software engineering consultant across various stacks and industries. I firmly believe that what has served me best is my strong interpersonal and communications skills combined with my core engineering competencies. Significant impact takes collaboration and coordination as well as excellent engineering.   
 
-### Core Competencies:
-- Software architecture & design 
-- Full Stack software development
-- Communicating with technical and non-technical stakeholders and leadership
-- Deep understanding of business needs to drive technical requirements 
-- Engineering mentorship and career growth 
+I'm a software engineer with nearly a decade of industry experience designing, building, and launching high-scale software across a variety of stacks and business sectors. I thrive on ambiguity, embrace complexity, and have deep experience translating difficult business problems into impactful software. I'm adept at communicating across technical and non-technical audiences and have led large interdisciplinary teams as both an individual contributor and an engineering manager.
 
+---
 
-If you want to talk about work feel free to email me or reach out on LinkedIn.
+### Meta — Seattle, WA *(2018–Present)*
+
+I joined Meta in 2018 as a software engineer on the Small Business Group and have grown with the organization across four roles over eight years.
+
+As a **Software Engineering Manager** (Sep 2024–Present) I lead a team of engineers building the capabilities and strategies that power how Meta communicates with the businesses that rely on our platforms.
+
+Before moving into management I was a **Staff Software Engineer** (Jan–Sep 2024) where I led a team of four mid-level and senior engineers responsible for delivering guidance systems across all Meta sales operations — work that drove billions in revenue and significant technological improvements to sales processes.
+
+Prior to that I spent five years as a **Senior and Software Engineer** on the same team, leading advertiser guidance and personalization efforts and contributing to Meta's COVID-19 and Ukraine War crisis response teams.
+
+### Exadel — Boulder, CO *(2015–2018)*
+
+Before Meta I spent three and a half years at Exadel as a software developer and engineer, building custom software solutions across a range of stacks and industries. This consulting background gave me exposure to a wide variety of technical environments early in my career and taught me to move quickly in unfamiliar codebases.
+
+---
+
+### Education
+
+**Gonzaga University** — BS, Computer Science *(2010–2014)*
+
+---
+
+### A few other things
+
+Outside of work I hold an FAA Private Pilot certificate. I also keep a [reading list](https://www.goodreads.com/user/show/98246601-patrick-anderson) if you're curious what's on my nightstand.
+
+If you want to talk shop, feel free to reach out via [email](mailto:pmanderson54@gmail.com) or [LinkedIn](https://www.linkedin.com/in/patrick-anderson-b377796b/).


### PR DESCRIPTION
Expands the thin single-paragraph work page into a proper professional
overview using LinkedIn history: four Meta roles (SWE → Staff SWE → SEM),
Exadel consulting background, Gonzaga CS degree, and FAA pilot cert.

https://claude.ai/code/session_01PBwTnMm39zGtV6C2uUvHB2