### PR TITLE
Add toggleable dark mode with prefers-color-scheme support

### DIFF
--- a/docs/_includes/head/custom.html
+++ b/docs/_includes/head/custom.html
@@ -1,0 +1,12 @@
+<link rel="stylesheet" href="/assets/css/dark-mode.css">
+<script>
+  // Apply saved/preferred theme before first paint to avoid flash
+  (function () {
+    var stored = localStorage.getItem('theme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (stored === 'dark' || (!stored && prefersDark)) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
+  })();
+</script>
+<script src="/assets/js/dark-mode.js" defer></script>

--- a/docs/assets/css/dark-mode.css
+++ b/docs/assets/css/dark-mode.css
@@ -1,0 +1,441 @@
+/* ============================================================
+   Dark mode overrides for Minimal Mistakes "default" skin
+   Applied when <html data-theme="dark"> is set
+   ============================================================ */
+
+/* Smooth transitions when toggling */
+html[data-theme="dark"],
+html[data-theme="dark"] *,
+html[data-theme="dark"] *::before,
+html[data-theme="dark"] *::after {
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Base */
+html[data-theme="dark"] body {
+  background-color: #252a34;
+  color: #eaeaea;
+}
+
+/* Masthead / top nav */
+html[data-theme="dark"] .masthead {
+  background-color: #1e2129;
+  border-bottom: 1px solid #1a1e26;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+html[data-theme="dark"] .masthead__inner-wrap {
+  background-color: #1e2129;
+}
+
+html[data-theme="dark"] .site-title,
+html[data-theme="dark"] .site-title:visited {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .site-subtitle {
+  color: #bfc5ca;
+}
+
+/* Navigation links */
+html[data-theme="dark"] .greedy-nav {
+  background-color: #1e2129;
+}
+
+html[data-theme="dark"] .greedy-nav a {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .greedy-nav a:hover {
+  color: #89cff0;
+}
+
+html[data-theme="dark"] .greedy-nav .visible-links a::before {
+  background: #89cff0;
+}
+
+html[data-theme="dark"] .greedy-nav__toggle {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .greedy-nav .hidden-links {
+  background-color: #1e2129;
+  border: 1px solid #1a1e26;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+html[data-theme="dark"] .greedy-nav .hidden-links a {
+  color: #eaeaea;
+  border-bottom: 1px solid #1a1e26;
+}
+
+html[data-theme="dark"] .greedy-nav .hidden-links a:hover {
+  background-color: #2e3444;
+  color: #89cff0;
+}
+
+/* Links */
+html[data-theme="dark"] a {
+  color: #89cff0;
+}
+
+html[data-theme="dark"] a:hover {
+  color: #b8e0f7;
+}
+
+html[data-theme="dark"] a:visited {
+  color: #a8d0ee;
+}
+
+/* Page / content area */
+html[data-theme="dark"] .page {
+  background-color: #252a34;
+}
+
+html[data-theme="dark"] .page__title {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .page__lead,
+html[data-theme="dark"] .page__content {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .page__content p,
+html[data-theme="dark"] .page__content li,
+html[data-theme="dark"] .page__content dt,
+html[data-theme="dark"] .page__content dd {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .page__content h1,
+html[data-theme="dark"] .page__content h2,
+html[data-theme="dark"] .page__content h3,
+html[data-theme="dark"] .page__content h4,
+html[data-theme="dark"] .page__content h5,
+html[data-theme="dark"] .page__content h6 {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .page__content h2 {
+  border-bottom: 1px solid #1a1e26;
+}
+
+/* Sidebar / author */
+html[data-theme="dark"] .sidebar {
+  background-color: #252a34;
+}
+
+html[data-theme="dark"] .author__name {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .author__bio {
+  color: #bfc5ca;
+}
+
+html[data-theme="dark"] .author__urls-wrapper button {
+  color: #bfc5ca;
+  border: 1px solid #1a1e26;
+  background-color: #2e3444;
+}
+
+html[data-theme="dark"] .author__urls {
+  background-color: #1e2129;
+  border: 1px solid #1a1e26;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+html[data-theme="dark"] .author__urls li a {
+  color: #bfc5ca;
+}
+
+html[data-theme="dark"] .author__urls li a:hover {
+  color: #89cff0;
+}
+
+/* Archive / post list */
+html[data-theme="dark"] .archive {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .archive__item-title a {
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .archive__item-title a:hover {
+  color: #89cff0;
+}
+
+html[data-theme="dark"] .archive__item-excerpt {
+  color: #bfc5ca;
+}
+
+html[data-theme="dark"] .list__item .page__meta,
+html[data-theme="dark"] .archive__item .page__meta {
+  color: #6f777d;
+}
+
+html[data-theme="dark"] .entries-list .list__item {
+  border-bottom: 1px solid #1a1e26;
+}
+
+/* Recent posts on home page */
+html[data-theme="dark"] h3.archive__subtitle {
+  color: #eaeaea;
+  border-bottom: 1px solid #1a1e26;
+}
+
+/* Page meta (reading time, date, tags) */
+html[data-theme="dark"] .page__meta {
+  color: #6f777d;
+}
+
+html[data-theme="dark"] .page__meta a {
+  color: #6f777d;
+}
+
+html[data-theme="dark"] .page__meta a:hover {
+  color: #89cff0;
+}
+
+html[data-theme="dark"] .page__taxonomy-item {
+  background-color: #2e3444;
+  color: #bfc5ca;
+  border: 1px solid #1a1e26;
+}
+
+html[data-theme="dark"] .page__taxonomy-item:hover {
+  background-color: #3a4156;
+  color: #89cff0;
+}
+
+/* Buttons */
+html[data-theme="dark"] .btn {
+  background-color: #2e3444;
+  color: #eaeaea;
+  border: 1px solid #1a1e26;
+}
+
+html[data-theme="dark"] .btn:hover {
+  background-color: #3a4156;
+  color: #89cff0;
+}
+
+html[data-theme="dark"] .btn--primary {
+  background-color: #3c6f94;
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .btn--primary:hover {
+  background-color: #4a82a8;
+}
+
+/* Code blocks */
+html[data-theme="dark"] code,
+html[data-theme="dark"] kbd,
+html[data-theme="dark"] samp {
+  background-color: #1e2129;
+  color: #b8e0f7;
+  border: 1px solid #1a1e26;
+}
+
+html[data-theme="dark"] pre {
+  background-color: #1e2129;
+  border: 1px solid #1a1e26;
+}
+
+html[data-theme="dark"] pre code {
+  background-color: transparent;
+  border: none;
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .highlight {
+  background-color: #1e2129;
+}
+
+html[data-theme="dark"] .highlight pre {
+  background-color: #1e2129;
+}
+
+/* Tables */
+html[data-theme="dark"] table {
+  border-color: #1a1e26;
+}
+
+html[data-theme="dark"] th {
+  background-color: #2e3444;
+  color: #eaeaea;
+  border-color: #1a1e26;
+}
+
+html[data-theme="dark"] td {
+  color: #eaeaea;
+  border-color: #1a1e26;
+}
+
+html[data-theme="dark"] tr:nth-child(even) td {
+  background-color: #2a2f3d;
+}
+
+/* Blockquotes */
+html[data-theme="dark"] blockquote {
+  background-color: #1e2129;
+  border-left-color: #89cff0;
+  color: #bfc5ca;
+}
+
+/* HR */
+html[data-theme="dark"] hr {
+  border-color: #1a1e26;
+}
+
+/* Footer */
+html[data-theme="dark"] .page__footer {
+  background-color: #1e2129;
+  color: #6f777d;
+}
+
+html[data-theme="dark"] .page__footer-copyright {
+  color: #6f777d;
+}
+
+html[data-theme="dark"] .page__footer a {
+  color: #bfc5ca;
+}
+
+html[data-theme="dark"] .page__footer a:hover {
+  color: #89cff0;
+}
+
+html[data-theme="dark"] .page__footer-follow .social-icons .svg-inline--fa {
+  color: #bfc5ca;
+}
+
+/* Breadcrumbs */
+html[data-theme="dark"] .breadcrumbs {
+  background-color: #2e3444;
+  border-bottom: 1px solid #1a1e26;
+}
+
+html[data-theme="dark"] .breadcrumbs a {
+  color: #bfc5ca;
+}
+
+/* Search */
+html[data-theme="dark"] .search-content {
+  background-color: #252a34;
+}
+
+html[data-theme="dark"] .search-content__form .search-input {
+  background-color: #1e2129;
+  border: 1px solid #1a1e26;
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] #search-input {
+  background-color: #1e2129;
+  color: #eaeaea;
+  border: 1px solid #1a1e26;
+}
+
+/* Notices */
+html[data-theme="dark"] .notice {
+  background-color: #2e3444;
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .notice--primary {
+  background-color: #1e3548;
+}
+
+html[data-theme="dark"] .notice--info {
+  background-color: #1e3040;
+}
+
+html[data-theme="dark"] .notice--warning {
+  background-color: #3d2e10;
+}
+
+html[data-theme="dark"] .notice--danger {
+  background-color: #3d1010;
+}
+
+html[data-theme="dark"] .notice--success {
+  background-color: #102d10;
+}
+
+/* Pagination */
+html[data-theme="dark"] .pagination a,
+html[data-theme="dark"] .pagination__item {
+  background-color: #2e3444;
+  color: #eaeaea;
+  border-color: #1a1e26;
+}
+
+html[data-theme="dark"] .pagination a:hover {
+  background-color: #3a4156;
+  color: #89cff0;
+}
+
+html[data-theme="dark"] .pagination__item--disabled {
+  background-color: #1e2129;
+  color: #6f777d;
+}
+
+/* ============================================================
+   Dark mode toggle button
+   ============================================================ */
+
+.dark-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin-left: 8px;
+  background: transparent;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 6px;
+  cursor: pointer;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  vertical-align: middle;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+}
+
+.dark-mode-toggle:hover {
+  background-color: rgba(128, 128, 128, 0.15);
+  border-color: rgba(128, 128, 128, 0.5);
+  transform: scale(1.05);
+}
+
+.dark-mode-toggle:focus {
+  outline: 2px solid #89cff0;
+  outline-offset: 2px;
+}
+
+.dark-mode-toggle:active {
+  transform: scale(0.95);
+}
+
+html[data-theme="dark"] .dark-mode-toggle {
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #eaeaea;
+}
+
+html[data-theme="dark"] .dark-mode-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+/* SVG icons inside the button */
+.dark-mode-toggle svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+  fill: currentColor;
+}

--- a/docs/assets/js/dark-mode.js
+++ b/docs/assets/js/dark-mode.js
@@ -1,0 +1,90 @@
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'theme';
+
+  var MOON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>';
+  var SUN_SVG  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1"  x2="12" y2="3"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="4.22" y1="4.22"  x2="5.64" y2="5.64"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="1"  y1="12" x2="3"  y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="18.36" y1="5.64"  x2="19.78" y2="4.22"  stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>';
+
+  function isDark() {
+    return document.documentElement.getAttribute('data-theme') === 'dark';
+  }
+
+  function applyTheme(dark) {
+    if (dark) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+    }
+  }
+
+  function savePreference(dark) {
+    try {
+      localStorage.setItem(STORAGE_KEY, dark ? 'dark' : 'light');
+    } catch (e) { /* storage unavailable */ }
+  }
+
+  function updateButton(btn, dark) {
+    btn.innerHTML = dark ? SUN_SVG : MOON_SVG;
+    btn.setAttribute('aria-label', dark ? 'Switch to light mode' : 'Switch to dark mode');
+    btn.setAttribute('title',      dark ? 'Switch to light mode' : 'Switch to dark mode');
+  }
+
+  function createToggleButton() {
+    var btn = document.createElement('button');
+    btn.id        = 'dark-mode-toggle';
+    btn.className = 'dark-mode-toggle';
+    btn.setAttribute('type', 'button');
+    updateButton(btn, isDark());
+
+    btn.addEventListener('click', function () {
+      var nowDark = !isDark();
+      applyTheme(nowDark);
+      savePreference(nowDark);
+      updateButton(btn, nowDark);
+    });
+
+    return btn;
+  }
+
+  function injectButton() {
+    // Avoid double-injection
+    if (document.getElementById('dark-mode-toggle')) return;
+
+    var btn = createToggleButton();
+
+    // Try to place it in the masthead nav for a natural look
+    var navLinks = document.querySelector('.greedy-nav .visible-links');
+    var greedyNav = document.querySelector('.greedy-nav');
+
+    if (greedyNav) {
+      // Insert after visible-links, before the overflow toggle
+      var overflowBtn = greedyNav.querySelector('.greedy-nav__toggle');
+      if (overflowBtn) {
+        greedyNav.insertBefore(btn, overflowBtn);
+      } else {
+        greedyNav.appendChild(btn);
+      }
+    } else {
+      // Fallback: float in top-right corner
+      btn.style.cssText = 'position:fixed;top:12px;right:12px;z-index:9999;';
+      document.body.appendChild(btn);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    injectButton();
+
+    // Respond to OS-level theme changes when the user has no stored preference
+    var mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', function (e) {
+      try {
+        if (!localStorage.getItem(STORAGE_KEY)) {
+          applyTheme(e.matches);
+          var btn = document.getElementById('dark-mode-toggle');
+          if (btn) updateButton(btn, e.matches);
+        }
+      } catch (err) { /* storage unavailable */ }
+    });
+  });
+})();


### PR DESCRIPTION
- _includes/head/custom.html: loads dark-mode.css and runs an
  inline script before first paint to apply the saved/preferred
  theme immediately, preventing flash-of-wrong-theme
- assets/css/dark-mode.css: comprehensive Minimal Mistakes overrides
  under html[data-theme="dark"], plus toggle button styles
- assets/js/dark-mode.js: injects a sun/moon button into the masthead
  nav, persists preference to localStorage, and listens for OS-level
  prefers-color-scheme changes when no explicit preference is set

https://claude.ai/code/session_01RLVgXAmhkZ2TmQTKi52J5F