### PR TITLE
Fix mobile dark mode nav: cut-off links and white hamburger button

### DIFF
--- a/docs/assets/css/dark-mode.css
+++ b/docs/assets/css/dark-mode.css
@@ -56,6 +56,8 @@ html[data-theme="dark"] .greedy-nav .visible-links a::before {
 
 html[data-theme="dark"] .greedy-nav__toggle {
   color: #eaeaea;
+  background-color: transparent;
+  border: none;
 }
 
 html[data-theme="dark"] .greedy-nav .hidden-links {

--- a/docs/assets/js/dark-mode.js
+++ b/docs/assets/js/dark-mode.js
@@ -65,6 +65,10 @@
       } else {
         greedyNav.appendChild(btn);
       }
+      // Trigger greedy-nav to recalculate which links fit now that we've added
+      // the toggle button — without this the nav JS sees stale available width
+      // and leaves "About" partially visible instead of moving it to the dropdown.
+      window.dispatchEvent(new Event('resize'));
     } else {
       // Fallback: float in top-right corner
       btn.style.cssText = 'position:fixed;top:12px;right:12px;z-index:9999;';


### PR DESCRIPTION
Dispatch a resize event after injecting the dark-mode toggle button so
the greedy-nav JS recalculates available width and properly collapses
overflow links into the dropdown (fixes "About" showing as ".bout").

Also set background-color: transparent and border: none on the
greedy-nav__toggle in dark mode — browsers give <button> a default
white/grey background that was jarring against the dark nav bar.

https://claude.ai/code/session_012aadzH4hkdHeREZ5yt6Nw6